### PR TITLE
Fix Gradle convention deprecation warning

### DIFF
--- a/gradle/java/build.gradle
+++ b/gradle/java/build.gradle
@@ -1,7 +1,9 @@
 apply plugin: 'java'
 
-sourceCompatibility = 17
-targetCompatibility = 17
+java {
+    sourceCompatibility = 17
+    targetCompatibility = 17
+}
 
 compileJava {
     options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"


### PR DESCRIPTION
Fixes Gradle JavaPluginConvention deprecation warnings that will cause the web3j plugins to stop working in Gradle 9+:

```
Script '/Users/stevensheehy/projects/oss/web3j-gradle-plugin/gradle/java/build.gradle': line 4
The org.gradle.api.plugins.JavaPluginConvention type has been deprecated. This is scheduled to be removed in Gradle 9.0. Consult the upgrading guide for further information: https://docs.gradle.org/8.7/userguide/upgrading_version_8.html#java_convention_deprecation
        at build_cfxj9i1s3k4es82kgnb359k8f.run(/Users/stevensheehy/projects/oss/web3j-gradle-plugin/gradle/java/build.gradle:4)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
        at build_aoyhe4wym7kz855rudt1kxzng.run(/Users/stevensheehy/projects/oss/web3j-gradle-plugin/build.gradle:22)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
```